### PR TITLE
Add support for LBRY

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "Kestrel",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/nkestrel/mediaurltimestamper",
@@ -37,7 +37,8 @@
         "*://*.bit.tube/*",
         "*://*.invidio.us/*",
         "*://*.youtube-nocookie.com/*",
-        "*://*.vidlii.com/*"
+        "*://*.vidlii.com/*",
+        "*://*.lbry.tv/*"
       ],
       "js": ["options/defaults.js",
              "scripts/websites.js",

--- a/scripts/websites.js
+++ b/scripts/websites.js
@@ -185,5 +185,14 @@ const websites = [
       parameter: "t",
       format: "seconds"
     }]
+  },
+  { id: "lbry",
+	domains: ["lbry.tv"],
+	methods: [{
+	  paths: ["/"],
+	  type: "query",
+	  parameter: "t",
+	  format: "seconds"
+	}]
   }
 ];

--- a/scripts/websites.js
+++ b/scripts/websites.js
@@ -194,5 +194,14 @@ const websites = [
 	  parameter: "t",
 	  format: "seconds"
 	}]
+  },
+  { id: "odysee",
+	domains: ["odysee.com"],
+	methods: [{
+	  paths: ["/"],
+	  type: "query",
+	  parameter: "t",
+	  format: "seconds"
+	}]
   }
 ];


### PR DESCRIPTION
I don't know how your naming scheme works, so i updated the version.
Adds support for [LBRY](lbry.tv), a Youtube alternative.